### PR TITLE
Add remote LanceDB instructions

### DIFF
--- a/3-embedding.py
+++ b/3-embedding.py
@@ -8,6 +8,7 @@ from lancedb.embeddings import get_registry
 from lancedb.pydantic import LanceModel, Vector
 from openai import OpenAI
 from utils.tokenizer import OpenAITokenizerWrapper
+from utils.db import connect_lancedb
 
 load_dotenv()
 
@@ -45,7 +46,7 @@ chunks = list(chunk_iter)
 # --------------------------------------------------------------
 
 # Create a LanceDB database
-db = lancedb.connect("data/lancedb")
+db = connect_lancedb()
 
 
 # Get the OpenAI embedding function

--- a/4-search.py
+++ b/4-search.py
@@ -1,11 +1,15 @@
 import lancedb
+from dotenv import load_dotenv
+from utils.db import connect_lancedb
+
+load_dotenv()
 
 # --------------------------------------------------------------
 # Connect to the database
 # --------------------------------------------------------------
 
 uri = "data/lancedb"
-db = lancedb.connect(uri)
+db = connect_lancedb(default_uri=uri)
 
 
 # --------------------------------------------------------------

--- a/5-chat.py
+++ b/5-chat.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import lancedb
+from utils.db import connect_lancedb
 from openai import OpenAI
 from dotenv import load_dotenv
 
@@ -18,7 +19,7 @@ def init_db():
     Returns:
         LanceDB table object
     """
-    db = lancedb.connect("data/lancedb")
+    db = connect_lancedb()
     return db.open_table("docling")
 
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ pip install -r requirements.txt
 
 ```bash
 OPENAI_API_KEY=your_api_key_here
+# Optional: connect to a remote LanceDB instance
+LANCEDB_URI=db://doc-analyzer-94a7s7
+LANCEDB_API_KEY=your_lancedb_api_key
+LANCEDB_REGION=us-east-1
 ```
 
 ### Running the Example
@@ -43,6 +47,9 @@ Execute the files in order to build and query the document database:
 3. Create embeddings and store in LanceDB: `python 3-embedding.py`
 4. Test basic search functionality: `python 4-search.py`
 5. Launch the Streamlit chat interface: `streamlit run 5-chat.py`
+
+If `LANCEDB_URI` is set to a remote database (e.g. `db://doc-analyzer-94a7s7`),
+the scripts above will use that instead of the local `data/lancedb` directory.
 
 Then open your browser and navigate to `http://localhost:8501` to interact with the document Q&A interface.
 

--- a/bulk_ingest.py
+++ b/bulk_ingest.py
@@ -3,6 +3,7 @@ import os
 from typing import List
 
 import lancedb
+from utils.db import connect_lancedb
 from docling.document_converter import DocumentConverter
 from docling.chunking import HybridChunker
 from lancedb.embeddings import get_registry
@@ -37,7 +38,7 @@ def main():
 
     os.makedirs(args.db_path, exist_ok=True)
 
-    db = lancedb.connect(args.db_path)
+    db = connect_lancedb(default_uri=args.db_path)
 
     if args.table in db.table_names():
         table = db.open_table(args.table)

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,0 +1,13 @@
+import os
+import lancedb
+
+def connect_lancedb(default_uri: str = "data/lancedb"):
+    """Connect to LanceDB using environment variables if available."""
+    uri = os.getenv("LANCEDB_URI", default_uri)
+    api_key = os.getenv("LANCEDB_API_KEY")
+    region = os.getenv("LANCEDB_REGION")
+
+    if uri.startswith("db://") and api_key:
+        return lancedb.connect(uri=uri, api_key=api_key, region=region)
+    return lancedb.connect(uri)
+


### PR DESCRIPTION
## Summary
- load environment variables in `4-search.py`
- document example remote LanceDB connection in the README

## Testing
- `python -m py_compile utils/db.py 3-embedding.py 4-search.py 5-chat.py bulk_ingest.py`


------
https://chatgpt.com/codex/tasks/task_e_6856f0a43c04832aa0f2af10cadb1e2e